### PR TITLE
Update pdf.js to 4834f1c

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "fs-plus": "2.x",
     "pathwatcher": "^2.0",
-    "pdf.js": "git://github.com/mozilla/pdf.js.git#ae92b6f96f8faf60eca9af9d3eff4782ae19dbb2"
+    "pdf.js": "git://github.com/mozilla/pdf.js.git#4834f1c28924b3322f00b8383ddb8478193be930"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/izuzak/atom-pdf-view/issues/18. 

I think that performance is worse than before -- not sure if that's related to pdf.js or to Atom's upgrade to Chrome 36 which happened with version 0.121.0. Tried investigating, but didn't find anything that I could do to improve performance. Will open another issue to track this.
