### PR TITLE
Speedup loading

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -6,14 +6,6 @@ require './../node_modules/pdf.js/build/singlefile/build/pdf.combined.js'
 
 module.exports =
 class PdfEditorView extends ScrollView
-  atom.deserializers.add(this)
-
-  @deserialize: ({filePath}) ->
-    if fs.isFileSync(filePath)
-      new PdfEditorView(filePath)
-    else
-      console.warn "Could not deserialize PDF editor for path '#{filePath}' because that file no longer exists"
-
   @content: ->
     @div class: 'pdf-view', tabindex: -1, =>
       @div outlet: 'container'
@@ -177,7 +169,7 @@ class PdfEditorView extends ScrollView
     @scrollTop(pageScrollPosition)
 
   serialize: ->
-    {@filePath, deserializer: 'PdfEditorView'}
+    {@filePath, deserializer: 'PdfEditorDeserializer'}
 
   getTitle: ->
     if @filePath?

--- a/lib/pdf-editor.coffee
+++ b/lib/pdf-editor.coffee
@@ -26,3 +26,13 @@ createPdfStatusView = ->
     view.attach()
   PdfGoToPageView = require  './pdf-goto-page-view.coffee'
   new PdfGoToPageView()
+
+PdfEditorDeserializer =
+  name: 'PdfEditorDeserializer'
+  deserialize: ({filePath}) ->
+    if require('fs-plus').isFileSync(filePath)
+      PdfEditorView ?= require './pdf-editor-view'
+      new PdfEditorView(filePath)
+    else
+      console.warn "Could not deserialize PDF editor for path '#{filePath}' because that file no longer exists"
+atom.deserializers.add PdfEditorDeserializer


### PR DESCRIPTION
Improve startup time and activation time by requiring and constructing stuff as late as possible. 

On my machine loading time dropped from 250ms to 34ms. Activation time is now ⩽5ms. It's still a lot, but I don't know how to speed it up further.

This pull request probably closes #37. 
