### PR TITLE
Proper scaling on HiDPI displays

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -101,8 +101,18 @@ class PdfEditorView extends ScrollView
         @pdfDocument.getPage(pdfPageNumber).then (pdfPage) =>
           viewport = pdfPage.getViewport(@currentScale)
           context = canvas.getContext('2d')
-          canvas.height = viewport.height
-          canvas.width = viewport.width
+
+          outputScale = window.devicePixelRatio
+          canvas.height = Math.floor(viewport.height) * outputScale
+          canvas.width = Math.floor(viewport.width) * outputScale
+          
+          if outputScale isnt 1
+            context._scaleX = outputScale
+            context._scaleY = outputScale
+            context.scale outputScale, outputScale
+            canvas.style.width = Math.floor(viewport.width) + 'px';
+            canvas.style.height = Math.floor(viewport.height) + 'px';
+
           @pageHeights.push(Math.floor(viewport.height))
 
           pdfPage.render({canvasContext: context, viewport: viewport})


### PR DESCRIPTION
Add proper scaling for HiDPI displays (fixes #27)
Code is based on:

https://github.com/mozilla/pdf.js/blob/c6c4583956b0b0c85aa6d5f8e20eacc16665f721/examples/text-selection/js/minimal.js#L51-L66

https://github.com/mozilla/pdf.js/blob/e294c8883a3da2f5012acaeb55be32b8fe57c53a/web/ui_utils.js#L93-L106

`context._scaleX`, `context._scaleY` is used internally by pdf.js
