### PR TITLE
Use web workers in pdf.js

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -1,8 +1,10 @@
 {$, ScrollView} = require 'atom'
 fs = require 'fs-plus'
 path = require 'path'
-require './../node_modules/pdf.js/build/singlefile/build/pdf.combined.js'
+require './../node_modules/pdf.js/build/generic/build/pdf.js'
 {File} = require 'pathwatcher'
+
+PDFJS.workerSrc = "file://" + path.resolve(__dirname, "../node_modules/pdf.js/build/generic/build/pdf.worker.js")
 
 module.exports =
 class PdfEditorView extends ScrollView

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/izuzak/atom-pdf-view",
   "license": "MIT",
   "scripts": {
-    "postinstall": "cd node_modules/pdf.js/ && node make singlefile"
+    "postinstall": "cd node_modules/pdf.js/ && node make generic"
   },
   "engines": {
     "atom": "*"
@@ -14,6 +14,6 @@
   "dependencies": {
     "fs-plus": "2.x",
     "pathwatcher": "^2.0",
-    "pdf.js": "git+https://github.com/mozilla/pdf.js.git#251b2cae2c14ffc8b9f29fd4384f27776c1cd239"
+    "pdf.js": "git+https://github.com/mozilla/pdf.js.git#v1.0.907"
   }
 }


### PR DESCRIPTION
Update pdf.js version to stable and use web worker-enabled build.
Split from #39.
