### PR TITLE
Remove pathwatcher dependency

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -2,9 +2,8 @@
 fs = require 'fs-plus'
 path = require 'path'
 require './../node_modules/pdf.js/build/generic/build/pdf.js'
-{File} = require 'pathwatcher'
 _ = require 'underscore-plus'
-{Disposable, CompositeDisposable} = require 'atom'
+{File, Disposable, CompositeDisposable} = require 'atom'
 
 PDFJS.workerSrc = "file://" + path.resolve(__dirname, "../node_modules/pdf.js/build/generic/build/pdf.worker.js")
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "fs-plus": "2.x",
-    "pathwatcher": "^4.0.1",
     "pdf.js": "git+https://github.com/mozilla/pdf.js.git#v1.0.907",
     "underscore-plus": "^1.6",
     "atom-space-pen-views": "^2.0.3"


### PR DESCRIPTION
Fixes #50 and fixes #55.

As of version 0.191.0, Atom exposes the File and Directory classes from pathwatcher, so this is no longer needed as a dependency. 