### PR TITLE
mouse-based panning & zooming, SyncTeX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Adds support for viewing PDF files in Atom. Powered by [PDF.js](https://github.c
 | Zoom out   | `cmd--` or `cmd-_` | `ctrl--` or `ctrl-_` |
 | Reset zoom | `cmd-0`            | `ctrl-0`             |
 
+You can also zoom by holding `ctrl` and using the mouse wheel.
+
 ### Status bar information
 
 Shows the number of the current page and total page count.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Shows the number of the current page and total page count.
 Jump to a specific page by either clicking on the page count in the status bar or by executing the `Pdf View: Go To Page` command from the command palette.
 
 ![](https://cloud.githubusercontent.com/assets/38924/3689767/ce223cce-1342-11e4-8b7b-b2e5bdbb3016.png)
+
+### SyncTeX
+
+For PDF files created by TeX using the `--synctex=1` option, a click on the PDF will take you to the corresponding source code. The `synctex` command has to be installed and available in the `PATH` for this to work.

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -90,6 +90,14 @@ class PdfEditorView extends ScrollView
       if @dragging
         @dragging = null
 
+    @on 'mousewheel', (e) =>
+      if e.ctrlKey
+        e.preventDefault
+        if e.originalEvent.wheelDelta > 0
+          @zoomIn()
+        else if e.originalEvent.wheelDelta < 0
+          @zoomOut()
+
   onScroll: ->
     if not @updating
       @scrollTopBeforeUpdate = @scrollTop()

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -1,4 +1,5 @@
 {$, ScrollView} = require 'atom-space-pen-views'
+{Point, TextEditor} = require 'atom'
 fs = require 'fs-plus'
 path = require 'path'
 require './../node_modules/pdfjs-dist/build/pdf.js'
@@ -7,20 +8,22 @@ _ = require 'underscore-plus'
 
 PDFJS.workerSrc = "file://" + path.resolve(__dirname, "../node_modules/pdfjs-dist/build/pdf.worker.js")
 
+{exec} = require 'child_process'
+
 module.exports =
 class PdfEditorView extends ScrollView
   @content: ->
     @div class: 'pdf-view', tabindex: -1, =>
       @div outlet: 'container'
 
-  initialize: (path) ->
+  initialize: (filePath) ->
     super
 
     @currentScale = 1.5
     @defaultScale = 1.5
     @scaleFactor = 10.0
 
-    @filePath = path
+    @filePath = filePath
     @file = new File(@filePath)
     @canvases = []
 
@@ -76,9 +79,12 @@ class PdfEditorView extends ScrollView
 
     @on 'mousedown', (e) =>
       @dragging = x: e.screenX, y: e.screenY, scrollTop: @scrollTop(), scrollLeft: @scrollLeft()
+      @simpleClick = true
 
     @on 'mousemove', (e) =>
       if @dragging
+        @simpleClick = false
+
         @scrollTop @dragging.scrollTop - (e.screenY - @dragging.y)
         @scrollLeft @dragging.scrollLeft - (e.screenX - @dragging.x)
         e.preventDefault()
@@ -97,6 +103,44 @@ class PdfEditorView extends ScrollView
           @zoomIn()
         else if e.originalEvent.wheelDelta < 0
           @zoomOut()
+
+  onCanvasClick: (page, e) ->
+    if @simpleClick
+      e.preventDefault()
+      @pdfDocument.getPage(page).then (pdfPage) =>
+        viewport = pdfPage.getViewport(@currentScale)
+        [x,y] = viewport.convertToPdfPoint(e.offsetX, $(@canvases[page-1]).height()-e.offsetY)
+        cmd = "synctex edit -o " + page + ":" + x + ":" + y + ":" + @filePath
+        exec cmd,
+          (error, stdout, stderr) =>
+            if not error
+              attrs = {}
+              for line in stdout.split('\n')
+                m = line.match /^([a-zA-Z]*):(.*)$/
+                if m
+                  attrs[m[1]] = m[2]
+              file = attrs.Input
+              line = attrs.Line
+              if file && line
+                editor = null
+                pathToOpen = path.normalize(attrs.Input)
+                lineToOpen = +attrs.Line
+                done = false
+                for pane in atom.workspace.getPanes()
+                  for editor in pane.getItems()
+                    if editor instanceof TextEditor
+                      if editor.getPath() == pathToOpen
+                        position = new Point(lineToOpen, -1)
+                        editor.scrollToBufferPosition(position, center: true)
+                        editor.setCursorBufferPosition(position)
+                        editor.moveToFirstCharacterOfLine()
+                        pane.activateItem(editor)
+                        pane.activate()
+                        done = true
+                if not done
+                  atom.workspace.open pathToOpen,
+                    initialLine: lineToOpen,
+                    initialColumn: 0
 
   onScroll: ->
     if not @updating
@@ -148,6 +192,7 @@ class PdfEditorView extends ScrollView
       for pdfPageNumber in [1..@pdfDocument.numPages]
         canvas = $("<canvas/>", class: "page-container").appendTo(@container)[0]
         @canvases.push(canvas)
+        do (pdfPageNumber) => $(canvas).on 'click', (e) => @onCanvasClick(pdfPageNumber, e)
 
       @renderPdf()
     , => @finishUpdate()

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -72,6 +72,24 @@ class PdfEditorView extends ScrollView
       'pdf-view:zoom-out': => @zoomOut()
       'pdf-view:reset-zoom': => @resetZoom()
 
+    @dragging = null
+
+    @on 'mousedown', (e) =>
+      @dragging = x: e.screenX, y: e.screenY, scrollTop: @scrollTop(), scrollLeft: @scrollLeft()
+
+    @on 'mousemove', (e) =>
+      if @dragging
+        @scrollTop @dragging.scrollTop - (e.screenY - @dragging.y)
+        @scrollLeft @dragging.scrollLeft - (e.screenX - @dragging.x)
+        e.preventDefault()
+
+    @on 'mouseup', (e) =>
+      @dragging = null
+
+    @on 'mouseleave', (e) =>
+      if @dragging
+        @dragging = null
+
   onScroll: ->
     if not @updating
       @scrollTopBeforeUpdate = @scrollTop()


### PR DESCRIPTION
Here are two things I hacked up because I wanted them for myself; I'm not sure how they fit with your idea of what `atom-pdf-view`'s feature set should be.

* SyncTeX support - for TeX users. A click on a PDF file will open the corresponding place in the TeX source.

* panning & zooming with the mouse.

The two features interact slightly because the SyncTeX behaviour is suppressed when the mouse moved during the click; they can easily be separated if you want to include one but not the other.
