### PR TITLE
Dont adjust size if the document is not loaded yet

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -223,6 +223,9 @@ class PdfEditorView extends ScrollView
     return zoomedPixels + spacesToSkip
 
   adjustSize: (factor) ->
+    if not @pdfDocument
+      return
+
     oldScrollTop = @scrollTop()
     oldPageHeights = @pageHeights.slice(0)
     @currentScale = @currentScale * factor


### PR DESCRIPTION
This _should_ fix https://github.com/izuzak/atom-pdf-view/issues/83 :pray: 