### PR TITLE
Adds text layer and copy&paste

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -117,7 +117,7 @@ class PdfEditorView extends ScrollView
     @on 'keydown', (e) =>
       if (e.ctrlKey or e.metaKey) and (e.keyCode is 67 or e.keyCode is 83)
         e.preventDefault()
-        document.execCommand 'copy'
+        atom.clipboard.write(@select())
 
 
   onCanvasClick: (page, e) ->
@@ -355,6 +355,26 @@ class PdfEditorView extends ScrollView
 
   getPath: ->
     @filePath
+
+  select: ->
+    selection = document.getSelection()
+    return unless selection.rangeCount
+    if selection.anchorNode.isEqualNode(selection.extentNode)
+      return selection.toString()
+    else
+      nodes = selection.getRangeAt(0).cloneContents().children
+      ranges = {}
+      for idx in [0..nodes.length - 1]
+        ranges[nodes[idx].style.top] = idx
+      idx = 0
+      retval = ''
+      while idx < nodes.length
+        end = ranges[nodes[idx].style.top]
+        for nodeIdx in [idx..end]
+          retval += nodes[nodeIdx].innerText
+        retval += '\n' if idx isnt nodes.length - 1
+        idx = end + 1
+      retval
 
   destroy: ->
     @detach()

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -372,7 +372,8 @@ class PdfEditorView extends ScrollView
         end = ranges[nodes[idx].style.top]
         for nodeIdx in [idx..end]
           retval += nodes[nodeIdx].innerText
-        retval += '\n' if idx isnt nodes.length - 1
+        if idx isnt nodes.length - 1
+          retval += if process.platform is 'win32' then '\r\n' else '\n'
         idx = end + 1
       retval
 

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -95,7 +95,10 @@ class PdfEditorView extends ScrollView
       $(document).unbind 'mouseup', @onMouseUp
       e.preventDefault()
 
-    @onMousedown = (e) =>
+    @on 'mousedown', (e) =>
+      return unless document.elementFromPoint(e.clientX, e.clientY).classList.contains('text-layer')
+      document.getSelection().empty();
+
       @simpleClick = true
       atom.workspace.paneForItem(this).activate()
       @dragging = x: e.screenX, y: e.screenY, scrollTop: @scrollTop(), scrollLeft: @scrollLeft()
@@ -221,7 +224,6 @@ class PdfEditorView extends ScrollView
         @canvases.push(canvas)
         do (pdfPageNumber) =>
           $(canvas).on 'click', (e) => @onCanvasClick(pdfPageNumber, e)
-          $(canvas).on 'mousedown', @onMouseDown
         textLayer = $("<div/>", class: "text-layer").appendTo(pageContainer)[0]
         @textLayers.push(textLayer)
 
@@ -255,7 +257,6 @@ class PdfEditorView extends ScrollView
           @pageHeights.push(Math.floor(viewport.height))
 
           pdfPage.getTextContent().then (content) =>
-            console.log(content)
             textLayer.style.height = canvas.style.height
             textLayer.style.width = canvas.style.width
             @textLayers.push textLayer

--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -114,7 +114,7 @@ class PdfEditorView extends ScrollView
     @on 'keydown', (e) =>
       if (e.ctrlKey or e.metaKey) and (e.keyCode is 67 or e.keyCode is 83)
         e.preventDefault()
-        atom.clipboard.write(@getSelectedText())
+        document.execCommand 'copy'
 
 
   onCanvasClick: (page, e) ->
@@ -255,17 +255,15 @@ class PdfEditorView extends ScrollView
           @pageHeights.push(Math.floor(viewport.height))
 
           pdfPage.getTextContent().then (content) =>
-            outputScale = getOutputScale context
-            cssScale = "scale(#{1 / outputScale.sx}, #{1 / outputScale.sy})"
+            console.log(content)
             textLayer.style.height = canvas.style.height
             textLayer.style.width = canvas.style.width
             @textLayers.push textLayer
-            # CustomStyle.setProp 'transform', canvas, cssScale
-            # CustomStyle.setProp 'transformOrigin', canvas, '0% 0%'
 
             textLayerBuilder = new DefaultTextLayerFactory().createTextLayerBuilder(textLayer, pdfPageNumber - 1, viewport)
             textLayerBuilder.setTextContent content
-            textLayerBuilder.renderLayer()
+            textLayerBuilder.render()
+
 
           pdfPage.render({canvasContext: context, viewport: viewport})
 
@@ -356,17 +354,6 @@ class PdfEditorView extends ScrollView
 
   getPath: ->
     @filePath
-
-  getSelectedText: ->
-    if window.getSelection()
-      return window.getSelection().toString()
-    else if document.getSelection()
-      return document.getSelection().toString()
-    else if document.selection and document.selection.type isnt "Control"
-      return document.selection.createRange().text
-    else
-      ""
-
 
   destroy: ->
     @detach()

--- a/lib/textlayerbuilder.js
+++ b/lib/textlayerbuilder.js
@@ -1,6 +1,6 @@
 /*
- * Extracted from Mozilla PDF.JS Viewer.
- * Below is a copy of original License.
+ * Extracted from Mozilla PDF.js Viewer.
+ * Credits attributed to PDF.js developers. Below is a copy of original License.
  */
 
 /* Copyright 2014 Mozilla Foundation

--- a/lib/textlayerbuilder.js
+++ b/lib/textlayerbuilder.js
@@ -1,0 +1,496 @@
+/*
+ * Extracted from Mozilla PDF.JS Viewer.
+ * Below is a copy of original License.
+ */
+
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+if (typeof PDFJS === 'undefined') {
+  require('./../node_modules/pdfjs-dist/build/pdf.js');
+}
+
+var MAX_TEXT_DIVS_TO_RENDER = 100000;
+var NonWhitespaceRegexp = /\S/;
+
+function isAllWhitespace(str) {
+  return !NonWhitespaceRegexp.test(str);
+}
+
+// optimised CSS custom property getter/setter
+var CustomStyle = (function CustomStyleClosure() {
+
+  // As noted on: http://www.zachstronaut.com/posts/2009/02/17/
+  //              animate-css-transforms-firefox-webkit.html
+  // in some versions of IE9 it is critical that ms appear in this list
+  // before Moz
+  var prefixes = ['ms', 'Moz', 'Webkit', 'O'];
+  var _cache = {};
+
+  function CustomStyle() {}
+
+  CustomStyle.getProp = function get(propName, element) {
+    // check cache only when no element is given
+    if (arguments.length === 1 && typeof _cache[propName] === 'string') {
+      return _cache[propName];
+    }
+
+    element = element || document.documentElement;
+    var style = element.style, prefixed, uPropName;
+
+    // test standard property first
+    if (typeof style[propName] === 'string') {
+      return (_cache[propName] = propName);
+    }
+
+    // capitalize
+    uPropName = propName.charAt(0).toUpperCase() + propName.slice(1);
+
+    // test vendor specific properties
+    for (var i = 0, l = prefixes.length; i < l; i++) {
+      prefixed = prefixes[i] + uPropName;
+      if (typeof style[prefixed] === 'string') {
+        return (_cache[propName] = prefixed);
+      }
+    }
+
+    //if all fails then set to undefined
+    return (_cache[propName] = 'undefined');
+  };
+
+  CustomStyle.setProp = function set(propName, element, str) {
+    var prop = this.getProp(propName);
+    if (prop !== 'undefined') {
+      element.style[prop] = str;
+    }
+  };
+
+  return CustomStyle;
+})();
+
+/**
+ * TextLayerBuilder provides text-selection functionality for the PDF.
+ * It does this by creating overlay divs over the PDF text. These divs
+ * contain text that matches the PDF text they are overlaying. This object
+ * also provides a way to highlight text that is being searched for.
+ * @class
+ */
+var TextLayerBuilder = (function TextLayerBuilderClosure() {
+  function TextLayerBuilder(options) {
+    this.textLayerDiv = options.textLayerDiv;
+    this.renderingDone = false;
+    this.divContentDone = false;
+    this.pageIdx = options.pageIndex;
+    this.pageNumber = this.pageIdx + 1;
+    this.matches = [];
+    this.viewport = options.viewport;
+    this.textDivs = [];
+    this.findController = options.findController || null;
+  }
+
+  TextLayerBuilder.prototype = {
+    _finishRendering: function TextLayerBuilder_finishRendering() {
+      this.renderingDone = true;
+
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('textlayerrendered', true, true, {
+        pageNumber: this.pageNumber
+      });
+      this.textLayerDiv.dispatchEvent(event);
+    },
+
+    renderLayer: function TextLayerBuilder_renderLayer() {
+      var textLayerFrag = document.createDocumentFragment();
+      var textDivs = this.textDivs;
+      var textDivsLength = textDivs.length;
+      var canvas = document.createElement('canvas');
+      var ctx = canvas.getContext('2d');
+
+      // No point in rendering many divs as it would make the browser
+      // unusable even after the divs are rendered.
+      if (textDivsLength > MAX_TEXT_DIVS_TO_RENDER) {
+        this._finishRendering();
+        return;
+      }
+
+      var lastFontSize;
+      var lastFontFamily;
+      for (var i = 0; i < textDivsLength; i++) {
+        var textDiv = textDivs[i];
+        if (textDiv.dataset.isWhitespace !== undefined) {
+          continue;
+        }
+
+        var fontSize = textDiv.style.fontSize;
+        var fontFamily = textDiv.style.fontFamily;
+
+        // Only build font string and set to context if different from last.
+        if (fontSize !== lastFontSize || fontFamily !== lastFontFamily) {
+          ctx.font = fontSize + ' ' + fontFamily;
+          lastFontSize = fontSize;
+          lastFontFamily = fontFamily;
+        }
+
+        var width = ctx.measureText(textDiv.textContent).width;
+        if (width > 0) {
+          textLayerFrag.appendChild(textDiv);
+          var transform;
+          if (textDiv.dataset.canvasWidth !== undefined) {
+            // Dataset values come of type string.
+            var textScale = textDiv.dataset.canvasWidth / width;
+            transform = 'scaleX(' + textScale + ')';
+          } else {
+            transform = '';
+          }
+          var rotation = textDiv.dataset.angle;
+          if (rotation) {
+            transform = 'rotate(' + rotation + 'deg) ' + transform;
+          }
+          if (transform) {
+            CustomStyle.setProp('transform' , textDiv, transform);
+          }
+        }
+      }
+
+      this.textLayerDiv.appendChild(textLayerFrag);
+      this._finishRendering();
+      this.updateMatches();
+    },
+
+    /**
+     * Renders the text layer.
+     * @param {number} timeout (optional) if specified, the rendering waits
+     *   for specified amount of ms.
+     */
+    render: function TextLayerBuilder_render(timeout) {
+      if (!this.divContentDone || this.renderingDone) {
+        return;
+      }
+
+      if (this.renderTimer) {
+        clearTimeout(this.renderTimer);
+        this.renderTimer = null;
+      }
+
+      if (!timeout) { // Render right away
+        this.renderLayer();
+      } else { // Schedule
+        var self = this;
+        this.renderTimer = setTimeout(function() {
+          self.renderLayer();
+          self.renderTimer = null;
+        }, timeout);
+      }
+    },
+
+    appendText: function TextLayerBuilder_appendText(geom, styles) {
+      var style = styles[geom.fontName];
+      var textDiv = document.createElement('div');
+      this.textDivs.push(textDiv);
+      if (isAllWhitespace(geom.str)) {
+        textDiv.dataset.isWhitespace = true;
+        return;
+      }
+      var tx = PDFJS.Util.transform(this.viewport.transform, geom.transform);
+      var angle = Math.atan2(tx[1], tx[0]);
+      if (style.vertical) {
+        angle += Math.PI / 2;
+      }
+      var fontHeight = Math.sqrt((tx[2] * tx[2]) + (tx[3] * tx[3]));
+      var fontAscent = fontHeight;
+      if (style.ascent) {
+        fontAscent = style.ascent * fontAscent;
+      } else if (style.descent) {
+        fontAscent = (1 + style.descent) * fontAscent;
+      }
+
+      var left;
+      var top;
+      if (angle === 0) {
+        left = tx[4];
+        top = tx[5] - fontAscent;
+      } else {
+        left = tx[4] + (fontAscent * Math.sin(angle));
+        top = tx[5] - (fontAscent * Math.cos(angle));
+      }
+      textDiv.style.left = left + 'px';
+      textDiv.style.top = top + 'px';
+      textDiv.style.fontSize = fontHeight + 'px';
+      textDiv.style.fontFamily = style.fontFamily;
+
+      textDiv.textContent = geom.str;
+      // |fontName| is only used by the Font Inspector. This test will succeed
+      // when e.g. the Font Inspector is off but the Stepper is on, but it's
+      // not worth the effort to do a more accurate test.
+      if (PDFJS.pdfBug) {
+        textDiv.dataset.fontName = geom.fontName;
+      }
+      // Storing into dataset will convert number into string.
+      if (angle !== 0) {
+        textDiv.dataset.angle = angle * (180 / Math.PI);
+      }
+      // We don't bother scaling single-char text divs, because it has very
+      // little effect on text highlighting. This makes scrolling on docs with
+      // lots of such divs a lot faster.
+      if (geom.str.length > 1) {
+        if (style.vertical) {
+          textDiv.dataset.canvasWidth = geom.height * this.viewport.scale;
+        } else {
+          textDiv.dataset.canvasWidth = geom.width * this.viewport.scale;
+        }
+      }
+    },
+
+    setTextContent: function TextLayerBuilder_setTextContent(textContent) {
+      this.textContent = textContent;
+
+      var textItems = textContent.items;
+      for (var i = 0, len = textItems.length; i < len; i++) {
+        this.appendText(textItems[i], textContent.styles);
+      }
+      this.divContentDone = true;
+    },
+
+    convertMatches: function TextLayerBuilder_convertMatches(matches) {
+      var i = 0;
+      var iIndex = 0;
+      var bidiTexts = this.textContent.items;
+      var end = bidiTexts.length - 1;
+      var queryLen = (this.findController === null ?
+                      0 : this.findController.state.query.length);
+      var ret = [];
+
+      for (var m = 0, len = matches.length; m < len; m++) {
+        // Calculate the start position.
+        var matchIdx = matches[m];
+
+        // Loop over the divIdxs.
+        while (i !== end && matchIdx >= (iIndex + bidiTexts[i].str.length)) {
+          iIndex += bidiTexts[i].str.length;
+          i++;
+        }
+
+        if (i === bidiTexts.length) {
+          console.error('Could not find a matching mapping');
+        }
+
+        var match = {
+          begin: {
+            divIdx: i,
+            offset: matchIdx - iIndex
+          }
+        };
+
+        // Calculate the end position.
+        matchIdx += queryLen;
+
+        // Somewhat the same array as above, but use > instead of >= to get
+        // the end position right.
+        while (i !== end && matchIdx > (iIndex + bidiTexts[i].str.length)) {
+          iIndex += bidiTexts[i].str.length;
+          i++;
+        }
+
+        match.end = {
+          divIdx: i,
+          offset: matchIdx - iIndex
+        };
+        ret.push(match);
+      }
+
+      return ret;
+    },
+
+    renderMatches: function TextLayerBuilder_renderMatches(matches) {
+      // Early exit if there is nothing to render.
+      if (matches.length === 0) {
+        return;
+      }
+
+      var bidiTexts = this.textContent.items;
+      var textDivs = this.textDivs;
+      var prevEnd = null;
+      var pageIdx = this.pageIdx;
+      var isSelectedPage = (this.findController === null ?
+        false : (pageIdx === this.findController.selected.pageIdx));
+      var selectedMatchIdx = (this.findController === null ?
+                              -1 : this.findController.selected.matchIdx);
+      var highlightAll = (this.findController === null ?
+                          false : this.findController.state.highlightAll);
+      var infinity = {
+        divIdx: -1,
+        offset: undefined
+      };
+
+      function beginText(begin, className) {
+        var divIdx = begin.divIdx;
+        textDivs[divIdx].textContent = '';
+        appendTextToDiv(divIdx, 0, begin.offset, className);
+      }
+
+      function appendTextToDiv(divIdx, fromOffset, toOffset, className) {
+        var div = textDivs[divIdx];
+        var content = bidiTexts[divIdx].str.substring(fromOffset, toOffset);
+        var node = document.createTextNode(content);
+        if (className) {
+          var span = document.createElement('span');
+          span.className = className;
+          span.appendChild(node);
+          div.appendChild(span);
+          return;
+        }
+        div.appendChild(node);
+      }
+
+      var i0 = selectedMatchIdx, i1 = i0 + 1;
+      if (highlightAll) {
+        i0 = 0;
+        i1 = matches.length;
+      } else if (!isSelectedPage) {
+        // Not highlighting all and this isn't the selected page, so do nothing.
+        return;
+      }
+
+      for (var i = i0; i < i1; i++) {
+        var match = matches[i];
+        var begin = match.begin;
+        var end = match.end;
+        var isSelected = (isSelectedPage && i === selectedMatchIdx);
+        var highlightSuffix = (isSelected ? ' selected' : '');
+
+        if (this.findController) {
+          this.findController.updateMatchPosition(pageIdx, i, textDivs,
+                                                  begin.divIdx, end.divIdx);
+        }
+
+        // Match inside new div.
+        if (!prevEnd || begin.divIdx !== prevEnd.divIdx) {
+          // If there was a previous div, then add the text at the end.
+          if (prevEnd !== null) {
+            appendTextToDiv(prevEnd.divIdx, prevEnd.offset, infinity.offset);
+          }
+          // Clear the divs and set the content until the starting point.
+          beginText(begin);
+        } else {
+          appendTextToDiv(prevEnd.divIdx, prevEnd.offset, begin.offset);
+        }
+
+        if (begin.divIdx === end.divIdx) {
+          appendTextToDiv(begin.divIdx, begin.offset, end.offset,
+                          'highlight' + highlightSuffix);
+        } else {
+          appendTextToDiv(begin.divIdx, begin.offset, infinity.offset,
+                          'highlight begin' + highlightSuffix);
+          for (var n0 = begin.divIdx + 1, n1 = end.divIdx; n0 < n1; n0++) {
+            textDivs[n0].className = 'highlight middle' + highlightSuffix;
+          }
+          beginText(end, 'highlight end' + highlightSuffix);
+        }
+        prevEnd = end;
+      }
+
+      if (prevEnd) {
+        appendTextToDiv(prevEnd.divIdx, prevEnd.offset, infinity.offset);
+      }
+    },
+
+    updateMatches: function TextLayerBuilder_updateMatches() {
+      // Only show matches when all rendering is done.
+      if (!this.renderingDone) {
+        return;
+      }
+
+      // Clear all matches.
+      var matches = this.matches;
+      var textDivs = this.textDivs;
+      var bidiTexts = this.textContent.items;
+      var clearedUntilDivIdx = -1;
+
+      // Clear all current matches.
+      for (var i = 0, len = matches.length; i < len; i++) {
+        var match = matches[i];
+        var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);
+        for (var n = begin, end = match.end.divIdx; n <= end; n++) {
+          var div = textDivs[n];
+          div.textContent = bidiTexts[n].str;
+          div.className = '';
+        }
+        clearedUntilDivIdx = match.end.divIdx + 1;
+      }
+
+      if (this.findController === null || !this.findController.active) {
+        return;
+      }
+
+      // Convert the matches on the page controller into the match format
+      // used for the textLayer.
+      this.matches = this.convertMatches(this.findController === null ?
+        [] : (this.findController.pageMatches[this.pageIdx] || []));
+      this.renderMatches(this.matches);
+    }
+  };
+  return TextLayerBuilder;
+})();
+
+/**
+ * @constructor
+ * @implements IPDFTextLayerFactory
+ */
+function DefaultTextLayerFactory() {}
+DefaultTextLayerFactory.prototype = {
+  /**
+   * @param {HTMLDivElement} textLayerDiv
+   * @param {number} pageIndex
+   * @param {PageViewport} viewport
+   * @returns {TextLayerBuilder}
+   */
+  createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport) {
+    return new TextLayerBuilder({
+      textLayerDiv: textLayerDiv,
+      pageIndex: pageIndex,
+      viewport: viewport
+    });
+  }
+};
+
+/**
+ * Returns scale factor for the canvas. It makes sense for the HiDPI displays.
+ * @return {Object} The object with horizontal (sx) and vertical (sy)
+                    scales. The scaled property is set to false if scaling is
+                    not required, true otherwise.
+ */
+function getOutputScale(ctx) {
+  var devicePixelRatio = window.devicePixelRatio || 1;
+  var backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
+                          ctx.mozBackingStorePixelRatio ||
+                          ctx.msBackingStorePixelRatio ||
+                          ctx.oBackingStorePixelRatio ||
+                          ctx.backingStorePixelRatio || 1;
+  var pixelRatio = devicePixelRatio / backingStoreRatio;
+  return {
+    sx: pixelRatio,
+    sy: pixelRatio,
+    scaled: pixelRatio !== 1
+  };
+}
+
+module.exports = {
+  CustomStyle,
+  TextLayerBuilder,
+  DefaultTextLayerFactory,
+  getOutputScale
+};

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
+    "atom-space-pen-views": "^2.0.3",
     "fs-plus": "2.x",
     "pdfjs-dist": "1.1.469",
-    "underscore-plus": "^1.6",
-    "atom-space-pen-views": "^2.0.3"
+    "underscore-plus": "^1.6"
   }
 }

--- a/styles/pdf-view.less
+++ b/styles/pdf-view.less
@@ -8,12 +8,63 @@
   overflow: auto;
 
   .page-container {
-    margin-left: auto;
-    margin-right: auto;
-    display: block;
-
+    position: relative;
     &:not(:last-child) {
       margin-bottom: 20px;
     }
   }
+
+  .text-layer {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden;
+    opacity: 0.2;
+
+    .highlight {
+      margin: -1px;
+      padding: 1px;
+
+      background-color: rgb(180, 0, 170);
+      border-radius: 4px;
+    }
+
+    .highlight.begin {
+      border-radius: 4px 0px 0px 4px;
+    }
+
+    .highlight.end {
+      border-radius: 0px 4px 4px 0px;
+    }
+
+    .highlight.middle {
+      border-radius: 0px;
+    }
+
+    .highlight.selected {
+      background-color: rgb(0, 100, 0);
+    }
+  }
+
+  .text-layer > div {
+    color: transparent;
+    position: absolute;
+    white-space: pre;
+    cursor: text;
+    -webkit-transform-origin: 0% 0%;
+    -moz-transform-origin: 0% 0%;
+    -o-transform-origin: 0% 0%;
+    -ms-transform-origin: 0% 0%;
+    transform-origin: 0% 0%;
+  }
+}
+
+::selection {
+  background: rgb(0,0,255);
+}
+
+::-moz-selection {
+  background: rgb(0,0,255);
 }

--- a/styles/pdf-view.less
+++ b/styles/pdf-view.less
@@ -9,55 +9,62 @@
 
   .page-container {
     position: relative;
+
     &:not(:last-child) {
       margin-bottom: 20px;
     }
-  }
 
-  .text-layer {
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    overflow: hidden;
-    opacity: 0.2;
-
-    .highlight {
-      margin: -1px;
-      padding: 1px;
-
-      background-color: rgb(180, 0, 170);
-      border-radius: 4px;
+    .canvas-container, .text-layer {
+      margin-left: auto;
+      margin-right: auto;
+      display: block;
     }
 
-    .highlight.begin {
-      border-radius: 4px 0px 0px 4px;
-    }
+    .text-layer {
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+      opacity: 0.2;
 
-    .highlight.end {
-      border-radius: 0px 4px 4px 0px;
-    }
+      .highlight {
+        margin: -1px;
+        padding: 1px;
 
-    .highlight.middle {
-      border-radius: 0px;
-    }
+        background-color: rgb(180, 0, 170);
+        border-radius: 4px;
 
-    .highlight.selected {
-      background-color: rgb(0, 100, 0);
-    }
-  }
+        .begin {
+          border-radius: 4px 0px 0px 4px;
+        }
 
-  .text-layer > div {
-    color: transparent;
-    position: absolute;
-    white-space: pre;
-    cursor: text;
-    -webkit-transform-origin: 0% 0%;
-    -moz-transform-origin: 0% 0%;
-    -o-transform-origin: 0% 0%;
-    -ms-transform-origin: 0% 0%;
-    transform-origin: 0% 0%;
+        .end {
+          border-radius: 0px 4px 4px 0px;
+        }
+
+        .middle {
+          border-radius: 0px;
+        }
+
+        .selected {
+          background-color: rgb(0, 100, 0);
+        }
+      }
+
+      div {
+        color: transparent;
+        position: absolute;
+        white-space: pre;
+        cursor: text;
+        -webkit-transform-origin: 0% 0%;
+        -moz-transform-origin: 0% 0%;
+        -o-transform-origin: 0% 0%;
+        -ms-transform-origin: 0% 0%;
+        transform-origin: 0% 0%;
+      }
+    }
   }
 }
 

--- a/styles/pdf-view.less
+++ b/styles/pdf-view.less
@@ -14,7 +14,7 @@
       margin-bottom: 20px;
     }
 
-    .canvas-container, .text-layer {
+    .canvas-container, .text-layer, canvas {
       margin-left: auto;
       margin-right: auto;
       display: block;


### PR DESCRIPTION
This adds a text layer on top of the original PDF canvas, along with a preliminary solution for copy and paste.

Changes made:

* DOM Hierarchy: I changed it for a bit to make writing stylesheets easier, and for the text layer builder to function properly. If it's too much, I will change it back.

* Hardwired hotkeys: Ctrl-C (Cmd-C) wouldn't function properly without explicitly specifying a "keydown" event in jQuery, so theres a new `@on` method call.

* `textlayerbuilder.js`: This is extracted from Mozilla's pdf.js viewer. I did not wish to do so as this adds a large chunk of code, but it appears that the code cannot be directly required from package.

**About copy & paste**: The fragmented nature of text contents passed by `Page.getTextContent()` makes it hard to find a universal way to copy flawlessly. So far, when copying multiple lines, the native `document.execCommand('copy')` is used. This won't preserve formatting if copy destination is in Atom, but works when copying to Word or TextEdit.
There is also a `select()` method that will add a line break after the contents that are approximately on the same line. Currently it's commented out since it only makes copied contents looks nicer *within Atom*. While the method would work for strictly formatted PDFs (e.g. TeX converted), it does not function very well for some irregularly formatted documents, or when word separation is purely done by pixel arrangements :joy: