### PR TITLE
Quote filenames containing whitespace in argument to SyncTeX if called via 'exec'.

### DIFF
--- a/lib/pdf-editor-view.coffee
+++ b/lib/pdf-editor-view.coffee
@@ -115,7 +115,7 @@ class PdfEditorView extends ScrollView
       @pdfDocument.getPage(page).then (pdfPage) =>
         viewport = pdfPage.getViewport(@currentScale)
         [x,y] = viewport.convertToPdfPoint(e.offsetX, $(@canvases[page-1]).height()-e.offsetY)
-        
+
         callback =
           (error, stdout, stderr) =>
             if not error
@@ -149,14 +149,16 @@ class PdfEditorView extends ScrollView
                     initialColumn: 0
 
         synctexPath = atom.config.get('pdf-view.syncTeXPath')
-        clickspec = page + ":" + x + ":" + y + ":" + @filePath
+        clickspec = page + ":" + x + ":" + y + ":"
         if synctexPath
+          clickspec += @filename
           execFile synctexPath, ["edit", "-o", clickspec], callback
         else
+          clickspec += if @filename.includes(' ') then '"' + @filePath + '"' else @filePath
           cmd = "synctex edit -o " + clickspec
           exec cmd, callback
-        
-        
+
+
 
   onScroll: ->
     if not @updating


### PR DESCRIPTION
See issue #91.

This patch is **not** thoroughly tested, as I do not have the opportunities to do that right now (– that being the reason I opened an *issue* instead of posting a pull request in the first place).

And you can think of other approaches to tackle the issue, too: Unconditionally quote, quote entire `clickspec` argument, quote upon other characters as well…