### PR TITLE
Add SyncTeX forward sync support

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -192,6 +192,35 @@ export default class PdfEditorView extends ScrollView {
     }
   }
 
+  forwardSync(texPath, lineNumber) {
+      let callback = ((error, stdout, stderr) => {
+        if (!error) {
+          stdout = stdout.replace(/\r\n/g, '\n');
+          let attrs = {};
+          for (let line of stdout.split('\n')) {
+            let m = line.match(/^([a-zA-Z]*):(.*)$/)
+            if (m) {
+              attrs[m[1]] = m[2];
+            }
+          }
+
+          let page = attrs.Page;
+          this.scrollToPage(page)
+        }
+      });
+
+      let synctexPath = atom.config.get('pdf-view.syncTeXPath');
+      let inputspec = [lineNumber, 0, texPath].join(':');
+
+      if (synctexPath) {
+        execFile(synctexPath, ["view", "-i", inputspec, "-o", this.filePath], callback);
+      } else {
+        let cmd = `synctex view -i "${inputspec}" -o "${this.filePath}"`;
+        exec(cmd, callback);
+      }
+  }
+
+
   onScroll() {
     if (!this.updating) {
       this.scrollTopBeforeUpdate = this.scrollTop();


### PR DESCRIPTION
Adds a method forwardSync to the PdfEditorView, which allows latex editors to sync the position in their tex file to the PDF view.

I added this along with an [update in atom-latex package](https://github.com/nsaje/atom-latex/commit/ad5c38087abcaa54ac544313b693c1aa7e8c392b) , which together make Atom a nice LaTeX editor with two-way PDF sync support.

I don't use JS often, so let me know if there's anything I could've done better. :smile: 

also, closes #107 
