### PR TITLE
Add fit to width

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -29,6 +29,7 @@ export default class PdfEditorView extends ScrollView {
     this.currentScale = 1.5;
     this.defaultScale = 1.5;
     this.scaleFactor = 10.0;
+    this.fitToWidth = atom.config.get('pdf-view.fitToWidth')
 
     this.filePath = filePath;
     this.file = new File(this.filePath);
@@ -268,6 +269,13 @@ export default class PdfEditorView extends ScrollView {
   renderPdf(scrollAfterRender = true) {
     this.centersBetweenPages = [];
     this.pageHeights = [];
+
+    if (this.fitToWidth) {
+      this.pdfDocument.getPage(1).then((pdfPage) => {
+        this.currentScale = this[0].clientWidth / pdfPage.getViewport(1.0).width
+      })
+      this.fitToWidth = false;
+    }
 
     for (let pdfPageNumber of _.range(1, this.pdfDocument.numPages+1)) {
       let canvas = this.canvases[pdfPageNumber-1];

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -15,6 +15,12 @@ export const config = {
     'default': "",
     title: "Path to synctex binary",
     description: "If not specified, look for `synctex` in `PATH`"
+  },
+  fitToWidth: {
+    type: "boolean",
+    'default': false,
+    title: "Fit to width",
+    description: "When opening a document, fit it to the pane width"
   }
 }
 

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -16,10 +16,10 @@ export const config = {
     title: "Path to synctex binary",
     description: "If not specified, look for `synctex` in `PATH`"
   },
-  fitToWidth: {
+  fitToWidthOnOpen: {
     type: "boolean",
     'default': false,
-    title: "Fit to width",
+    title: "Fit to width on open",
     description: "When opening a document, fit it to the pane width"
   }
 }


### PR DESCRIPTION
Adds a Fit to width option in the config. If set, document will be scaled to the current buffer on first render.

BTW, is there any better way to get buffer width than `this[0].clientWidth`, or is that alright? I couldn't find any other way.

closes #73