### PR TITLE
Add option to change SyncTeX click behaviour

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -45,15 +45,16 @@ export default class PdfEditorView extends ScrollView {
 
     let disposables = new CompositeDisposable();
 
-    let onFileChangeCallback = _.debounce(() => {
+    let needsUpdateCallback = _.debounce(() => {
       if (this.updating) {
-        this.fileChanged = true;
+        this.needsUpdate = true;
       } else {
         this.updatePdf();
       }
     }, 100);
 
-    disposables.add(this.file.onDidChange(onFileChangeCallback));
+    disposables.add(atom.config.onDidChange('pdf-view.reverseSyncBehaviour', needsUpdateCallback));
+    disposables.add(this.file.onDidChange(needsUpdateCallback));
 
     let moveLeftCallback = (() => this.scrollLeft(this.scrollLeft() - $(window).width() / 20));
     let moveRightCallback = (() => this.scrollRight(this.scrollRight() + $(window).width() / 20));
@@ -224,13 +225,13 @@ export default class PdfEditorView extends ScrollView {
 
   finishUpdate() {
     this.updating = false;
-    if (this.fileChanged) {
+    if (this.needsUpdate) {
       this.updatePdf();
     }
   }
 
   updatePdf() {
-    this.fileChanged = false;
+    this.needsUpdate = false;
 
     if (!fs.existsSync(this.filePath)) {
       return;

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -13,7 +13,6 @@ global.PDFJS = {workerSrc: "temp", cMapUrl:"temp", cMapPacked:true};
 require('./../node_modules/pdfjs-dist/build/pdf.js');
 PDFJS.workerSrc = "file://" + path.resolve(__dirname, "../node_modules/pdfjs-dist/build/pdf.worker.js");
 PDFJS.cMapUrl = "file://" + path.resolve(__dirname, "../node_modules/pdfjs-dist/cmaps")+"/";
-
 let {exec, execFile} = require('child_process');
 
 export default class PdfEditorView extends ScrollView {
@@ -132,8 +131,8 @@ export default class PdfEditorView extends ScrollView {
     });
   }
 
-  onCanvasClick(page, e) {
-    if (this.simpleClick && atom.config.get('pdf-view.enableSyncTeX')) {
+  reverseSync(page, e) {
+    if (this.simpleClick) {
       e.preventDefault();
       this.pdfDocument.getPage(page).then((pdfPage) => {
         let viewport = pdfPage.getViewport(this.currentScale);
@@ -251,6 +250,16 @@ export default class PdfEditorView extends ScrollView {
     this.container.find("canvas").remove();
     this.canvases = [];
 
+    let reverseSyncClicktype = null
+    switch(atom.config.get('pdf-view.reverseSyncBehaviour')) {
+      case 'Click':
+        reverseSyncClicktype = 'click'
+        break
+      case 'Double click':
+        reverseSyncClicktype = 'dblclick'
+        break
+    }
+
     PDFJS.getDocument(pdfData).then((pdfDocument) => {
       this.pdfDocument = pdfDocument;
       this.totalPageNumber = this.pdfDocument.numPages;
@@ -258,7 +267,9 @@ export default class PdfEditorView extends ScrollView {
       for (let pdfPageNumber of _.range(1, this.pdfDocument.numPages+1)) {
         let canvas = $("<canvas/>", {class: "page-container"}).appendTo(this.container)[0];
         this.canvases.push(canvas);
-        $(canvas).on('click', (e) => this.onCanvasClick(pdfPageNumber, e));
+        if (reverseSyncClicktype) {
+          $(canvas).on(reverseSyncClicktype, (e) => this.reverseSync(pdfPageNumber, e));
+        }
       }
 
       this.renderPdf();

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -4,11 +4,12 @@ var path = null;
 var PdfEditorView = null;
 
 export const config = {
-  enableSyncTeX: {
-    type: "boolean",
-    'default': true,
-    title: "Enable SyncTeX",
-    description: "A click on a PDF generated with the `--synctex=1` option will take you to the source."
+  reverseSyncBehaviour: {
+    type: "string",
+    enum: ['Disabled', 'Click', 'Double click'],
+    'default': 'Click',
+    title: "SyncTeX Reverse sync behaviour",
+    description: "Specify the action on the PDF generated with the `--synctex=1` option that takes you to the source."
   },
   syncTeXPath: {
     type: "string",


### PR DESCRIPTION
The action can now be specified in the config. It can be either Disabled, Click or Double click.

I also renamed the function to reverseSync(), since it makes more sense combined with #111 .

closes #110