### PR TITLE
Use the first SyncTeX record on forwardSync

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -201,6 +201,10 @@ export default class PdfEditorView extends ScrollView {
           for (let line of stdout.split('\n')) {
             let m = line.match(/^([a-zA-Z]*):(.*)$/)
             if (m) {
+              if (m[1] in attrs) {
+                break;
+              }
+
               attrs[m[1]] = m[2];
             }
           }


### PR DESCRIPTION
I've been playing with `forwardSync` function in atom-pdf-view which works pretty well except that it doesn't always sync to the right page. The problem is that `synctex view...` produces a list of records where the first is likely to be the most accurate. Unfortunately, in the current version, each subsequent record clobbers the previous one, so sometimes `forwardSync` will jump to the wrong page. This PR fixes the issue by stopping parsing once we've hit the second record, ensuring that the jump is made to the first page.

Sorry for the wall of text.

Thanks for adding the forwardSync feature. It's a real boon to those of us using LaTeX in Atom.