### PR TITLE
Upgraded pdf.js to 1.6.264 to fix #129

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fs-plus": "2.x",
-    "pdfjs-dist": "1.3.146",
+    "pdfjs-dist": "1.6.264",
     "loophole": "1.1.0",
     "node-ensure": "0.0.0",
     "underscore-plus": "^1.6",


### PR DESCRIPTION
Updating pdf.js fixed the Problem in #129.
Synctex and "go to page" are working.
What is not working: The status line always shows "Page 1/.." regardless of the current page.