### PR TITLE
Allow scrollToPage only after updating is complete

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -35,6 +35,7 @@ export default class PdfEditorView extends ScrollView {
     this.scrollTopBeforeUpdate = scrollTop;
     this.scrollLeftBeforeUpdate = scrollLeft;
     this.canvases = [];
+    this.updating = false;
 
     this.updatePdf(closeOnError = true);
 
@@ -43,7 +44,6 @@ export default class PdfEditorView extends ScrollView {
     this.centersBetweenPages = [];
     this.pageHeights = [];
     this.maxPageWidth = 0;
-    this.updating = false;
     this.toScaleFactor = 1.0;
 
     let disposables = new CompositeDisposable();
@@ -267,6 +267,10 @@ export default class PdfEditorView extends ScrollView {
     if (this.toScaleFactor != 1) {
       this.adjustSize(1);
     }
+    if (this.scrollToPageAfterUpdate) {
+      this.scrollToPage(this.scrollToPageAfterUpdate)
+      delete this.scrollToPageAfterUpdate
+    }
   }
 
   updatePdf(closeOnError = false) {
@@ -463,6 +467,11 @@ export default class PdfEditorView extends ScrollView {
   }
 
   scrollToPage(pdfPageNumber) {
+    if (this.updating) {
+      this.scrollToPageAfterUpdate = pdfPageNumber
+      return
+    }
+
     if (!this.pdfDocument || isNaN(pdfPageNumber)) {
       return;
     }


### PR DESCRIPTION
Calling `forwardSync` immediately after opening fails if the document is still updating. Moving the reset of the update flag before loading the document and adding check in `scrollToPage` fixes.