### PR TITLE
Add next/previous page

### DIFF
--- a/keymaps/pdf-view.json
+++ b/keymaps/pdf-view.json
@@ -1,6 +1,8 @@
 {
   ".pdf-view": {
-    "ctrl-g": "pdf-view:go-to-page"
+    "ctrl-g": "pdf-view:go-to-page",
+    "cmd-left": "pdf-view:go-to-previous-page",
+    "cmd-right": "pdf-view:go-to-next-page"
   },
 
   ".platform-darwin .pdf-view": {

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -92,6 +92,16 @@ export default class PdfEditorView extends ScrollView {
         if (atom.workspace.getActivePaneItem() === this) {
           this.resetZoom();
         }
+      },
+      'pdf-view:go-to-next-page': () => {
+        if (atom.workspace.getActivePaneItem() === this) {
+          this.goToNextPage();
+        }
+      },
+      'pdf-view:go-to-previous-page': () => {
+        if (atom.workspace.getActivePaneItem() === this) {
+          this.goToPreviousPage();
+        }
       }
     });
 
@@ -396,6 +406,14 @@ export default class PdfEditorView extends ScrollView {
 
   resetZoom() {
     return this.adjustSize(this.defaultScale / this.currentScale);
+  }
+
+  goToNextPage() {
+    return this.scrollToPage(this.currentPageNumber + 1);
+  }
+
+  goToPreviousPage() {
+    return this.scrollToPage(this.currentPageNumber - 1);
   }
 
   computeZoomedScrollTop(oldScrollTop, oldPageHeights) {


### PR DESCRIPTION
Simply adds 'go to previous/next page'.

- Useful for browsing .pdf slides, e.g. Beamers.
- Command + left/right arrow key = previous/next page.