### PR TITLE
Declare x,y before using

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -150,6 +150,7 @@ export default class PdfEditorView extends ScrollView {
       e.preventDefault();
       this.pdfDocument.getPage(page).then((pdfPage) => {
         let viewport = pdfPage.getViewport(this.currentScale);
+        let x,y;
         [x,y] = viewport.convertToPdfPoint(e.offsetX, $(this.canvases[page - 1]).height() - e.offsetY);
 
         let callback = ((error, stdout, stderr) => {


### PR DESCRIPTION
Reverse sync was broken when I installed this package. Now it works!

This should resolve https://github.com/izuzak/atom-pdf-view/issues/140