### PR TITLE
Workaround for #139, plus zooming issues on non-retina screens

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -378,10 +378,10 @@ export default class PdfEditorView extends ScrollView {
           canvas.height = Math.floor(viewport.height) * outputScale;
           canvas.width = Math.floor(viewport.width) * outputScale;
 
-		  context._scaleX = outputScale;
+          context._scaleX = outputScale;
           context._scaleY = outputScale;
           context.scale(outputScale, outputScale);
-		  context._transformMatrix = [outputScale, 0, 0, outputScale, 0, 0];
+          context._transformMatrix = [outputScale, 0, 0, outputScale, 0, 0];
           canvas.style.width = Math.floor(viewport.width) + 'px';
           canvas.style.height = Math.floor(viewport.height) + 'px';
 

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -378,13 +378,12 @@ export default class PdfEditorView extends ScrollView {
           canvas.height = Math.floor(viewport.height) * outputScale;
           canvas.width = Math.floor(viewport.width) * outputScale;
 
-          if (outputScale != 1) {
-            context._scaleX = outputScale;
-            context._scaleY = outputScale;
-            context.scale(outputScale, outputScale);
-            canvas.style.width = Math.floor(viewport.width) + 'px';
-            canvas.style.height = Math.floor(viewport.height) + 'px';
-          }
+		  context._scaleX = outputScale;
+          context._scaleY = outputScale;
+          context.scale(outputScale, outputScale);
+		  context._transformMatrix = [outputScale, 0, 0, outputScale, 0, 0];
+          canvas.style.width = Math.floor(viewport.width) + 'px';
+          canvas.style.height = Math.floor(viewport.height) + 'px';
 
           this.pageHeights[pdfPageNumber - 1] = Math.floor(viewport.height);
 


### PR DESCRIPTION
Not sure if this is the best way, but here's the workaround. Following the commit message:

1) Directly set `context._transformMatrix` in `renderPdf()` as a workaround for issue #139.
2) Removed the check `if(outputScale != 1)` so that scaling works better on non-retina screens.
Zooming on a non-retina screen _after moving the window from a retina screen_ used to change the resolution of the rendered image without also changing the size of the image on the screen (so for example zooming out would just make things blurrier). Moreover the original fix for #139 screwed up other elements in the document on non-retina screens without this additional change.