### PR TITLE
Add basic URI handling

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -345,6 +345,10 @@ export default class PdfEditorView extends ScrollView {
       this.scrollToPage(this.scrollToPageAfterUpdate)
       delete this.scrollToPageAfterUpdate
     }
+    if (this.scrollToNamedDestAfterUpdate) {
+      this.scrollToNamedDest(this.scrollToNamedDestAfterUpdate)
+      delete this.scrollToNamedDestAfterUpdate
+    }
     if (this.forwardSyncAfterUpdate) {
       this.forwardSync(this.forwardSyncAfterUpdate.texPath, this.forwardSyncAfterUpdate.lineNumber)
       delete this.forwardSyncAfterUpdate
@@ -565,6 +569,22 @@ export default class PdfEditorView extends ScrollView {
     pageScrollPosition = (this.pageHeights.slice(0, (pdfPageNumber-1)).reduce(((x,y) => x+y), 0)) + (pdfPageNumber - 1) * 20
 
     return this.scrollTop(pageScrollPosition);
+  }
+
+  scrollToNamedDest(namedDest) {
+    if (this.updating) {
+      this.scrollToNamedDestAfterUpdate = namedDest
+      return
+    }
+
+    if (!this.pdfDocument) {
+      return
+    }
+
+    this.pdfDocument.getDestination(namedDest)
+      .then(destRef => this.pdfDocument.getPageIndex(destRef[0]))
+      .then(pageNumber => this.scrollToPage(pageNumber + 1))
+      .catch(() => atom.notifications.addError(`Cannot find named destination ${namedDest}.`))
   }
 
   serialize() {

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -67,7 +67,7 @@ export function handleURI(parsedUri) {
 
   const filePath = query.path || pathnameToFilePath(parsedUri.pathname)
 
-  atom.workspace.open(uriToPath(parsedUri)).then(view => {
+  atom.workspace.open(filePath).then(view => {
     if (view) {
       if (query.source && query.line) {
         view.forwardSync(query.source, query.line)

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -65,7 +65,7 @@ export function handleURI(parsedUri) {
     }
   }
 
-  console.log(query)
+  const filePath = query.path || pathnameToFilePath(parsedUri.pathname)
 
   atom.workspace.open(uriToPath(parsedUri)).then(view => {
     if (view) {
@@ -80,8 +80,8 @@ export function handleURI(parsedUri) {
   })
 }
 
-function uriToPath(parsedUri) {
-  let filePath = decodeURI(parsedUri.pathname || '')
+function pathnameToFilePath(pathname) {
+  let filePath = decodeURI(pathname || '')
 
   if (process.platform === 'win32') {
     filePath = filePath.replace(/\//g, '\\').replace(/^(.+)\|/, '$1:').replace(/\\([A-Z]:\\)/, '$1')

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -2,6 +2,7 @@
 
 var path = null;
 var PdfEditorView = null;
+var querystring = null;
 
 export const config = {
   reverseSyncBehaviour: {
@@ -45,6 +46,50 @@ export function activate(state) {
 
 export function deactivate() {
   this.subscription.dispose();
+}
+
+export function handleURI(parsedUri) {
+  const query = Object.assign({}, parsedUri.query)
+
+  if (parsedUri.hash) {
+    // Allow query parameters to exist in hash to main compatability with Adobe
+    // PDF style urls.
+    if (parsedUri.hash.includes('=')) {
+      if (querystring === null) {
+        querystring = require('querystring')
+      }
+
+      Object.assign(query, querystring.parse(parsedUri.hash.substring(1)))
+    } else {
+      query.nameddest = parsedUri.hash.substring(1)
+    }
+  }
+
+  console.log(query)
+
+  atom.workspace.open(uriToPath(parsedUri)).then(view => {
+    if (view) {
+      if (query.source && query.line) {
+        view.forwardSync(query.source, query.line)
+      } else if (query.page) {
+        view.scrollToPage(query.page)
+      } else if (query.nameddest) {
+        view.scrollToNamedDest(query.nameddest)
+      }
+    }
+  })
+}
+
+function uriToPath(parsedUri) {
+  let filePath = decodeURI(parsedUri.pathname || '')
+
+  if (process.platform === 'win32') {
+    filePath = filePath.replace(/\//g, '\\').replace(/^(.+)\|/, '$1:').replace(/\\([A-Z]:\\)/, '$1')
+  } else if (!filePath.startsWith('/')) {
+    filePath = `/${filePath}`
+  }
+
+  return filePath
 }
 
 // Files with these extensions will be opened as PDFs

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "node-ensure": "0.0.0",
     "underscore-plus": "^1.6",
     "atom-space-pen-views": "^2.0.3"
+  },
+  "uriHandler": {
+    "method": "handleURI"
   }
 }


### PR DESCRIPTION
This PR adds basic [URI handling](http://flight-manual.atom.io/hacking-atom/sections/handling-uris/) for the atom scheme which was added in v1.23. The main purpose is to handle SyncTeX forward requests from outside Atom and to support some of the Adobe PDF style URL parameters.

Currently supported is 

* `source` - path to TeX source file (or knitr source if patchSynctex was used).
* `line` - line number in source file
* `page` - page number in PDF file
* `nameddest` - named bookmark in PDF file.

Query parameters are allowed to exist in the hash in addition to the query portion since this is the Adobe PDF usage. A hash with no parameters is assumed to be a named destination. For example

* `atom://pdf-view/foo/bar.pdf` opens `/foo/bar.pdf`
* `atom://pdf-view/foo/bar.pdf?source=quux.tex&line=23` opens then syncs to line 23 of `quux.tex`
* `atom://pdf-view/foo/bar.pdf?page=2` or `atom://pdf-view/foo/bar.pdf#page=2` opens page 2
* `atom://pdf-view/foo/bar.pdf#wibble` or `atom://pdf-view/foo/bar.pdf?nameddest=wibble`opens to the wibble bookmark.
* `atom://pdf-view?path=c:\foo\bar.pdf` should also work for those that don't wan't encode file system paths like drives or UNC paths.

There are more parameters listed [here](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf). I can add more if you are interested. I just added the ones that seem to me to be the most pertinent.