### PR TITLE
Add basic URI handling (v2)

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -345,6 +345,10 @@ export default class PdfEditorView extends ScrollView {
       this.scrollToPage(this.scrollToPageAfterUpdate)
       delete this.scrollToPageAfterUpdate
     }
+    if (this.scrollToNamedDestAfterUpdate) {
+      this.scrollToNamedDest(this.scrollToNamedDestAfterUpdate)
+      delete this.scrollToNamedDestAfterUpdate
+    }
     if (this.forwardSyncAfterUpdate) {
       this.forwardSync(this.forwardSyncAfterUpdate.texPath, this.forwardSyncAfterUpdate.lineNumber)
       delete this.forwardSyncAfterUpdate
@@ -565,6 +569,22 @@ export default class PdfEditorView extends ScrollView {
     pageScrollPosition = (this.pageHeights.slice(0, (pdfPageNumber-1)).reduce(((x,y) => x+y), 0)) + (pdfPageNumber - 1) * 20
 
     return this.scrollTop(pageScrollPosition);
+  }
+
+  scrollToNamedDest(namedDest) {
+    if (this.updating) {
+      this.scrollToNamedDestAfterUpdate = namedDest
+      return
+    }
+
+    if (!this.pdfDocument) {
+      return
+    }
+
+    this.pdfDocument.getDestination(namedDest)
+      .then(destRef => this.pdfDocument.getPageIndex(destRef[0]))
+      .then(pageNumber => this.scrollToPage(pageNumber + 1))
+      .catch(() => atom.notifications.addError(`Cannot find named destination ${namedDest}.`))
   }
 
   serialize() {

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -2,6 +2,7 @@
 
 var path = null;
 var PdfEditorView = null;
+var querystring = null;
 
 export const config = {
   reverseSyncBehaviour: {
@@ -45,6 +46,50 @@ export function activate(state) {
 
 export function deactivate() {
   this.subscription.dispose();
+}
+
+export function handleURI(parsedUri) {
+  const query = Object.assign({}, parsedUri.query)
+
+  if (parsedUri.hash) {
+    // Allow query parameters to exist in hash to main compatability with Adobe
+    // PDF style urls.
+    if (parsedUri.hash.includes('=')) {
+      if (querystring === null) {
+        querystring = require('querystring')
+      }
+
+      Object.assign(query, querystring.parse(parsedUri.hash.substring(1)))
+    } else {
+      query.nameddest = parsedUri.hash.substring(1)
+    }
+  }
+
+  const filePath = query.path || pathnameToFilePath(parsedUri.pathname)
+
+  atom.workspace.open(filePath).then(view => {
+    if (view) {
+      if (query.source && query.line) {
+        view.forwardSync(query.source, query.line)
+      } else if (query.page) {
+        view.scrollToPage(query.page)
+      } else if (query.nameddest) {
+        view.scrollToNamedDest(query.nameddest)
+      }
+    }
+  })
+}
+
+function pathnameToFilePath(pathname) {
+  let filePath = decodeURI(pathname || '')
+
+  if (process.platform === 'win32') {
+    filePath = filePath.replace(/\//g, '\\').replace(/^(.+)\|/, '$1:').replace(/\\([A-Z]:\\)/, '$1')
+  } else if (!filePath.startsWith('/')) {
+    filePath = `/${filePath}`
+  }
+
+  return filePath
 }
 
 // Files with these extensions will be opened as PDFs

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
     "node-ensure": "0.0.0",
     "underscore-plus": "^1.6",
     "atom-space-pen-views": "^2.0.3"
+  },
+  "uriHandler": {
+    "method": "handleURI",
+    "deferActivation": false
   }
 }


### PR DESCRIPTION
Adds same URI handling as in #198, but disables deferred activation to avoid #200.

It appears that registering the package as a URI handler enables deferred activation as described [here](http://flight-manual.atom.io/hacking-atom/sections/handling-uris/#controlling-activation-deferral).