### PR TITLE
Reload file when someone tries to `open` file

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -48,24 +48,43 @@ export default class PdfEditorView extends ScrollView {
 
     let disposables = new CompositeDisposable();
 
-    let needsUpdateCallback = _.debounce(() => {
+    let needsUpdateCallback = () => {
       if (this.updating) {
         this.needsUpdate = true;
       } else {
         this.updatePdf();
       }
-    }, 100);
+    }
 
     disposables.add(atom.config.onDidChange('pdf-view.reverseSyncBehaviour', needsUpdateCallback));
 
+    disposables.add(this.file.onDidChange(() => {
+      if (atom.config.get('pdf-view.autoReloadOnUpdate')) {
+        needsUpdateCallback();
+      } else {
+        this.fileUpdated = true;
+      }
+    }));
+
     let autoReloadDisposable;
     let setupAutoReload = () => {
-      if (atom.config.get('pdf-view.autoReloadOnUpdate')) {
-        autoReloadDisposable = this.file.onDidChange(needsUpdateCallback)
-        disposables.add(autoReloadDisposable);
-      } else if(autoReloadDisposable) {
-        disposables.remove(autoReloadDisposable);
-        autoReloadDisposable.dispose()
+      if (!atom.config.get('pdf-view.autoReloadOnUpdate')) {
+        autoReloadDisposable = atom.workspace.onDidOpen((e) => {
+          if (e.item == this && this.fileUpdated) {
+            this.fileUpdated = false;
+            needsUpdateCallback();
+          }
+        });
+      } else {
+        if(autoReloadDisposable) {
+          disposables.remove(autoReloadDisposable);
+          autoReloadDisposable.dispose();
+        }
+
+        if (this.fileUpdated) {
+          this.fileUpdated = false;
+          needsUpdateCallback();
+        }
       }
     }
     disposables.add(atom.config.observe('pdf-view.autoReloadOnUpdate', setupAutoReload));


### PR DESCRIPTION
If the "Auto reload on update" is disabled. The file never updates. Even if someone manually tries to open a file or calls `atom.workspace.open`.

With this PR, when "Auto reload on update" is disabled, and someone clicks on the file on sidebar, and if the file is updated, the file should reload.

The file should also reload when some other plugin, for example [`latex`](https://github.com/thomasjo/atom-latex), calls `atom.workspace.open` after compiling the pdf.

This fixes #161. Hope it doesn't break anything else! :P