### PR TITLE
Adding command Zoom Fit #153

### DIFF
--- a/keymaps/pdf-view.json
+++ b/keymaps/pdf-view.json
@@ -6,15 +6,16 @@
   },
 
   ".platform-darwin .pdf-view": {
+    "alt-cmd-=": "pdf-view:zoom-fit",
     "cmd-+": "pdf-view:zoom-in",
     "cmd-=": "pdf-view:zoom-in",
     "cmd--": "pdf-view:zoom-out",
     "cmd-_": "pdf-view:zoom-out",
-    "cmd-0": "pdf-view:reset-zoom",
-    "alt-cmd-=": "pdf-view:zoom-fit",
+    "cmd-0": "pdf-view:reset-zoom"
   },
 
   ".platform-win32 .pdf-view, .platform-linux .pdf-view": {
+    "alt-ctrl-=": "pdf-view:zoom-fit",
     "ctrl-+": "pdf-view:zoom-in",
     "ctrl-=": "pdf-view:zoom-in",
     "ctrl--": "pdf-view:zoom-out",

--- a/keymaps/pdf-view.json
+++ b/keymaps/pdf-view.json
@@ -10,7 +10,8 @@
     "cmd-=": "pdf-view:zoom-in",
     "cmd--": "pdf-view:zoom-out",
     "cmd-_": "pdf-view:zoom-out",
-    "cmd-0": "pdf-view:reset-zoom"
+    "cmd-0": "pdf-view:reset-zoom",
+    "alt-cmd-=": "pdf-view:zoom-fit",
   },
 
   ".platform-win32 .pdf-view, .platform-linux .pdf-view": {

--- a/keymaps/pdf-view.json
+++ b/keymaps/pdf-view.json
@@ -6,7 +6,7 @@
   },
 
   ".platform-darwin .pdf-view": {
-    "alt-cmd-=": "pdf-view:zoom-fit",
+    "alt-cmd-9": "pdf-view:zoom-fit",
     "cmd-+": "pdf-view:zoom-in",
     "cmd-=": "pdf-view:zoom-in",
     "cmd--": "pdf-view:zoom-out",
@@ -15,7 +15,7 @@
   },
 
   ".platform-win32 .pdf-view, .platform-linux .pdf-view": {
-    "alt-ctrl-=": "pdf-view:zoom-fit",
+    "alt-ctrl-9": "pdf-view:zoom-fit",
     "ctrl-+": "pdf-view:zoom-in",
     "ctrl-=": "pdf-view:zoom-in",
     "ctrl--": "pdf-view:zoom-out",

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -429,6 +429,8 @@ export default class PdfEditorView extends ScrollView {
         }
       }
 
+      this.maxPageWidth = 0;
+
       if (this.fitToWidthOnOpen) {
         Promise.all(
           _.range(1, this.pdfDocument.numPages + 1).map((pdfPageNumber) =>
@@ -495,7 +497,7 @@ export default class PdfEditorView extends ScrollView {
     }, () => this.finishUpdate());
   }
 
-  computeMaxPageWidth(){
+  computeMaxPageWidthAndTryZoomFit(){
     Promise.all(
       _.range(1, this.pdfDocument.numPages + 1).map((pdfPageNumber) =>
         this.pdfDocument.getPage(pdfPageNumber).then((pdfPage) =>
@@ -505,22 +507,18 @@ export default class PdfEditorView extends ScrollView {
     ).then((pdfPageWidths) => {
       this.maxPageWidth = Math.max(...pdfPageWidths);
       this.zoomFit();
-      // console.log('Max width: ' + this.maxPageWidth);
     })
   }
 
   zoomFit() {
     if (this.maxPageWidth == 0) {
-      this.computeMaxPageWidth();
+      this.computeMaxPageWidthAndTryZoomFit();
       return;
     }
     let fitScale = this[0].clientWidth / this.maxPageWidth;
-    // console.log('Fit scale: ' + fitScale);
-    // console.log('Current scale: ' + this.currentScale);
-    // console.log('To scale factor: ' + this.toScaleFactor);
     return this.adjustSize(fitScale / (this.currentScale *  this.toScaleFactor));
   }
-  
+
   zoomOut() {
     return this.adjustSize(100 / (100 + this.scaleFactor));
   }

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -108,6 +108,11 @@ export default class PdfEditorView extends ScrollView {
     disposables.add(new Disposable(() => $(window).off('resize', resizeHandler)));
 
     atom.commands.add('atom-workspace', {
+      'pdf-view:zoom-fit': () => {
+        if (atom.workspace.getActivePaneItem() === this) {
+          this.zoomFit();
+        }
+      },
       'pdf-view:zoom-in': () => {
         if (atom.workspace.getActivePaneItem() === this) {
           this.zoomIn();
@@ -490,6 +495,32 @@ export default class PdfEditorView extends ScrollView {
     }, () => this.finishUpdate());
   }
 
+  computeMaxPageWidth(){
+    Promise.all(
+      _.range(1, this.pdfDocument.numPages + 1).map((pdfPageNumber) =>
+        this.pdfDocument.getPage(pdfPageNumber).then((pdfPage) =>
+          pdfPage.getViewport(1.0).width
+        )
+      )
+    ).then((pdfPageWidths) => {
+      this.maxPageWidth = Math.max(...pdfPageWidths);
+      this.zoomFit();
+      // console.log('Max width: ' + this.maxPageWidth);
+    })
+  }
+
+  zoomFit() {
+    if (this.maxPageWidth == 0) {
+      this.computeMaxPageWidth();
+      return;
+    }
+    let fitScale = this[0].clientWidth / this.maxPageWidth;
+    // console.log('Fit scale: ' + fitScale);
+    // console.log('Current scale: ' + this.currentScale);
+    // console.log('To scale factor: ' + this.toScaleFactor);
+    return this.adjustSize(fitScale / (this.currentScale *  this.toScaleFactor));
+  }
+  
   zoomOut() {
     return this.adjustSize(100 / (100 + this.scaleFactor));
   }


### PR DESCRIPTION
Add the command zoom fit so that it can be done anytime, not only when openning pdfs.
The corresponding shortcut is mapped to alt-cmd-= (macos) and alt-ctrl-= (windows/linux).