### PR TITLE
Add command to toggle display of binary data

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -28,7 +28,7 @@ export default class PdfEditorView extends ScrollView {
     this.currentScale = scale ? scale : 1.5;
     this.defaultScale = 1.5;
     this.scaleFactor = 10.0;
-    this.fitToWidthOnOpen = !scale && atom.config.get('pdf-view.fitToWidthOnOpen')
+    this.fitToWidthOnOpen = !scale && atom.config.get('pdf-view.fitToWidthOnOpen');
 
     this.filePath = filePath;
     this.file = new File(this.filePath);
@@ -39,12 +39,16 @@ export default class PdfEditorView extends ScrollView {
 
     this.updatePdf(true);
 
+    this.pdfViewElements = [];
+    this.binaryViewEditor = null;
+
     this.currentPageNumber = 0;
     this.totalPageNumber = 0;
     this.centersBetweenPages = [];
     this.pageHeights = [];
     this.maxPageWidth = 0;
     this.toScaleFactor = 1.0;
+    this.dragging = null;
 
     let disposables = new CompositeDisposable();
 
@@ -99,47 +103,47 @@ export default class PdfEditorView extends ScrollView {
     let scrollCallback = (() => this.onScroll());
     let resizeHandler = (() => this.setCurrentPageNumber());
 
-    let elem = this;
-
     atom.commands.add('.pdf-view', {
       'core:move-left': moveLeftCallback,
       'core:move-right': moveRightCallback
     });
 
-    elem.on('scroll', scrollCallback);
-    disposables.add(new Disposable(() => $(window).off('scroll', scrollCallback)));
-
+    this.on('scroll', scrollCallback);
     $(window).on('resize', resizeHandler);
-    disposables.add(new Disposable(() => $(window).off('resize', resizeHandler)));
+    
+    disposables.add(new Disposable(() => {
+      $(window).off('scroll', scrollCallback);
+      $(window).off('resize', resizeHandler);
+    }));
 
     atom.commands.add('atom-workspace', {
       'pdf-view:zoom-fit': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.zoomFit();
         }
       },
       'pdf-view:zoom-in': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.zoomIn();
         }
       },
       'pdf-view:zoom-out': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.zoomOut();
         }
       },
       'pdf-view:reset-zoom': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.resetZoom();
         }
       },
       'pdf-view:go-to-next-page': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.goToNextPage();
         }
       },
       'pdf-view:go-to-previous-page': () => {
-        if (atom.workspace.getActivePaneItem() === this) {
+        if (hasFocus()) {
           this.goToPreviousPage();
         }
       },
@@ -148,9 +152,10 @@ export default class PdfEditorView extends ScrollView {
       }
     });
 
-    this.dragging = null;
-
     this.onMouseMove = (e) => {
+      if (this.binaryView) {
+        return;
+      }
       if (this.dragging) {
         this.simpleClick = false;
 
@@ -161,6 +166,9 @@ export default class PdfEditorView extends ScrollView {
     };
 
     this.onMouseUp = (e) => {
+      if (this.binaryView) {
+        return;
+      }
       this.dragging = null;
       $(document).unbind('mousemove', this.onMouseMove);
       $(document).unbind('mouseup', this.onMouseUp);
@@ -168,6 +176,9 @@ export default class PdfEditorView extends ScrollView {
     };
 
     this.on('mousedown', (e) => {
+      if (this.binaryView) {
+        return;
+      }
       this.simpleClick = true;
       atom.workspace.paneForItem(this).activate();
       this.dragging = {x: e.screenX, y: e.screenY, scrollTop: this.scrollTop(), scrollLeft: this.scrollLeft()};
@@ -177,6 +188,9 @@ export default class PdfEditorView extends ScrollView {
     });
 
     this.on('mousewheel', (e) => {
+      if (this.binaryView) {
+        return;
+      }
       if (e.ctrlKey) {
         e.preventDefault();
         if (e.originalEvent.wheelDelta > 0) {
@@ -186,6 +200,41 @@ export default class PdfEditorView extends ScrollView {
         }
       }
     });
+  }
+
+  get binaryView() {
+    return this.hasClass('binary-view');
+  }
+
+  set binaryView(enabled) {
+    const container = this.container[0];
+    if (!!enabled === this.binaryView) {
+      return;
+    }
+    if (!this.binaryViewEditor) {
+      const {TextBuffer, TextEditor} = require('atom');
+      const buffer = TextBuffer.loadSync(this.filePath);
+      this.binaryViewEditor = new TextEditor({buffer, readOnly: true});
+    }
+    if (enabled) {
+      this.addClass('binary-view');
+      for (const el of Array.from(container.children)) {
+        container.removeChild(el);
+        this.pdfViewElements.push(el);
+      }
+      container.appendChild(this.binaryViewEditor.element);
+    }
+    else {
+      this.removeClass('binary-view');
+      container.removeChild(this.binaryViewEditor.element);
+      while (this.pdfViewElements.length) {
+        container.appendChild(this.pdfViewElements.shift());
+      }
+    }
+  }
+
+  hasFocus() {
+    return !this.binaryView && atom.workspace.getActivePaneItem() === this;
   }
 
   setNightMode() {
@@ -344,6 +393,10 @@ export default class PdfEditorView extends ScrollView {
 
 
   onScroll() {
+    if (this.binaryView) {
+      return;
+    }
+
     if (!this.updating) {
       this.scrollTopBeforeUpdate = this.scrollTop();
       this.scrollLeftBeforeUpdate = this.scrollLeft();
@@ -353,7 +406,7 @@ export default class PdfEditorView extends ScrollView {
   }
 
   setCurrentPageNumber() {
-    if (!this.pdfDocument) {
+    if (!this.pdfDocument || this.binaryView) {
       return;
     }
 

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -118,32 +118,32 @@ export default class PdfEditorView extends ScrollView {
 
     atom.commands.add('atom-workspace', {
       'pdf-view:zoom-fit': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.zoomFit();
         }
       },
       'pdf-view:zoom-in': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.zoomIn();
         }
       },
       'pdf-view:zoom-out': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.zoomOut();
         }
       },
       'pdf-view:reset-zoom': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.resetZoom();
         }
       },
       'pdf-view:go-to-next-page': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.goToNextPage();
         }
       },
       'pdf-view:go-to-previous-page': () => {
-        if (hasFocus()) {
+        if (this.hasFocus()) {
           this.goToPreviousPage();
         }
       },

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -10,7 +10,8 @@ export function activate(state) {
   subscriptions = new CompositeDisposable(
     atom.workspace.addOpener(openUri),
     atom.packages.onDidActivateInitialPackages(createPdfStatusView),
-    atom.config.observe('pdf-view.fileExtensions', updateFileExtensions)
+    atom.config.observe('pdf-view.fileExtensions', updateFileExtensions),
+    atom.commands.add('atom-workspace', 'pdf-view:toggle-binary-view', toggleBinaryView)
   );
 }
 
@@ -87,6 +88,17 @@ function openUri(uriToOpen) {
     }
     return new PdfEditorView(uriToOpen);
   }
+}
+
+function toggleBinaryView() {
+  if(PdfEditorView === null) {
+    PdfEditorView = require('./pdf-editor-view');
+  }
+  const paneItem = atom.workspace.getActivePaneItem();
+  if(!paneItem || !(paneItem instanceof PdfEditorView)) {
+    return;
+  }
+  paneItem.binaryView = !paneItem.binaryView;
 }
 
 function createPdfStatusView() {

--- a/lib/pdf-editor.js
+++ b/lib/pdf-editor.js
@@ -1,57 +1,23 @@
 "use babel";
 
-var path = null;
-var PdfEditorView = null;
-var querystring = null;
-
-export const config = {
-  reverseSyncBehaviour: {
-    type: "string",
-    enum: ['Disabled', 'Click', 'Double click'],
-    'default': 'Click',
-    title: "SyncTeX Reverse sync behaviour",
-    description: "Specify the action on the PDF generated with the `--synctex=1` option that takes you to the source."
-  },
-  syncTeXPath: {
-    type: "string",
-    'default': "",
-    title: "Path to synctex binary",
-    description: "If not specified, look for `synctex` in `PATH`"
-  },
-  fitToWidthOnOpen: {
-    type: "boolean",
-    'default': false,
-    title: "Fit to width on open",
-    description: "When opening a document, fit it to the pane width"
-  },
-  paneToUseInSynctex: {
-    type: "string",
-    'enum' : ['default', 'left', 'right', 'up', 'down'],
-    'default': 'default',
-    title: "Pane to use when opening new tex files",
-    description: "When using reverse sync and a new tex source file has to be opened, use the provided pane to open the new file. 'default' will use the pane of the PDF viewer."
-  },
-  autoReloadOnUpdate: {
-    type: "boolean",
-    'default': true,
-    title: "Auto reload on update",
-    description: "Auto reload when the file is updated"
-  },
-  nightMode: {
-    type: "boolean",
-    default: false,
-    title: "Night Mode",
-    description: "Inverts the colors of the pdf"
-  }
-}
+let path = null;
+let PdfEditorView = null;
+let querystring = null;
+let subscriptions = null;
+const {CompositeDisposable} = require('atom');
 
 export function activate(state) {
-  this.subscription = atom.workspace.addOpener(openUri);
-  atom.packages.onDidActivateInitialPackages(createPdfStatusView);
+  subscriptions = new CompositeDisposable(
+    atom.workspace.addOpener(openUri),
+    atom.packages.onDidActivateInitialPackages(createPdfStatusView),
+    atom.config.observe('pdf-view.fileExtensions', updateFileExtensions)
+  );
 }
 
 export function deactivate() {
-  this.subscription.dispose();
+  if (subscriptions) {
+    subscriptions.dispose();
+  }
 }
 
 export function handleURI(parsedUri) {
@@ -99,7 +65,15 @@ function pathnameToFilePath(pathname) {
 }
 
 // Files with these extensions will be opened as PDFs
-const pdfExtensions = new Set(['.pdf']);
+const pdfExtensions = new Set();
+
+function updateFileExtensions(extensions) {
+  pdfExtensions.clear();
+  for (let extension of extensions) {
+    extension = extension.toLowerCase().replace(/^\.*/, '.');
+    pdfExtensions.add(extension);
+  }
+}
 
 function openUri(uriToOpen) {
   if (path === null) {

--- a/menus/pdf-view.cson
+++ b/menus/pdf-view.cson
@@ -1,0 +1,5 @@
+'context-menu':
+  '.pdf-view': [
+    'label': 'Toggle Binary View'
+    'command': 'pdf-view:toggle-binary-view'
+  ]

--- a/package.json
+++ b/package.json
@@ -22,5 +22,54 @@
   "uriHandler": {
     "method": "handleURI",
     "deferActivation": false
+  },
+  "configSchema": {
+    "reverseSyncBehaviour": {
+      "type": "string",
+      "enum": ["Disabled", "Click", "Double click"],
+      "default": "Click",
+      "title": "SyncTeX Reverse sync behaviour",
+      "description": "Specify the action on the PDF generated with the `--synctex=1` option that takes you to the source."
+    },
+    "syncTeXPath": {
+      "type": "string",
+      "default": "",
+      "title": "Path to synctex binary",
+      "description": "If not specified, look for `synctex` in `PATH`."
+    },
+    "fitToWidthOnOpen": {
+      "type": "boolean",
+      "default": false,
+      "title": "Fit to width on open",
+      "description": "When opening a document, fit it to the pane width."
+    },
+    "paneToUseInSynctex": {
+      "type": "string",
+      "enum" : ["default", "left", "right", "up", "down"],
+      "default": "default",
+      "title": "Pane to use when opening new TeX files",
+      "description": "When using reverse sync and a new TeX source file has to be opened, use the provided pane to open the new file. 'default' will use the pane of the PDF viewer."
+    },
+    "autoReloadOnUpdate": {
+      "type": "boolean",
+      "default": true,
+      "title": "Auto-reload on update",
+      "description": "Automatically reload when the file is updated."
+    },
+    "nightMode": {
+      "type": "boolean",
+      "default": false,
+      "title": "Night Mode",
+      "description": "Inverts the colours of the PDF."
+    },
+    "fileExtensions": {
+      "type": "array",
+      "default": ["pdf", "ai"],
+      "title": "PDF file extensions",
+      "description": "Files with these extensions will be opened as PDFs.",
+      "items": {
+        "type": "string"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds two enhancements:

* A `toggle-binary-view` command to temporarily display the raw binary data (fixes #184).

* A package setting to customise which file extensions are to be opened as PDFs. I've added `ai` to the default list, because Adobe Illustrator documents are essentially just PDF files with extra metadata thrown in.

If there's anything I've missed, please let me know.