### PR TITLE
Clean up workers after PDF closed

### DIFF
--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -110,7 +110,7 @@ export default class PdfEditorView extends ScrollView {
 
     this.on('scroll', scrollCallback);
     $(window).on('resize', resizeHandler);
-    
+
     disposables.add(new Disposable(() => {
       $(window).off('scroll', scrollCallback);
       $(window).off('resize', resizeHandler);
@@ -734,6 +734,9 @@ export default class PdfEditorView extends ScrollView {
   }
 
   destroy() {
+    try {
+      this.pdfDocument.destroy();
+    } catch {}
     return this.detach();
   }
 

--- a/lib/pdf-editor-view.js
+++ b/lib/pdf-editor-view.js
@@ -736,7 +736,9 @@ export default class PdfEditorView extends ScrollView {
   destroy() {
     try {
       this.pdfDocument.destroy();
-    } catch {}
+    } catch (e) {
+      console.error(e);
+    }
     return this.detach();
   }
 


### PR DESCRIPTION
This calls the destroy method on the PDF document when the view is closed. Without this call, workers persist in memory, and accumulate with each PDF opened or refresh (e.g., for LaTeX).

This will help with #225, but may not clean up all workers. When compiling LaTeX, it apparently makes intermediate PDFs with invalid contents. With auto reload enabled, this package will try to display these bad PDFs and PDF.js will throw an error somewhere, but the worker created for that failed PDF persists.